### PR TITLE
Port missing features

### DIFF
--- a/__tests__/AsyncStatsD.spec.ts
+++ b/__tests__/AsyncStatsD.spec.ts
@@ -1,7 +1,7 @@
 import {MonitorOptions} from '../src';
 import {AsyncStatsD} from '../src/AsyncStatsD';
 import {mocked} from 'ts-jest/utils';
-import {StatsCb} from 'hot-shots';
+import {StatsCb, Tags} from 'hot-shots';
 import { Logger } from '../src/Logger';
 import {consoleLogger} from '../src/loggers';
 
@@ -26,14 +26,14 @@ describe('AsyncStatsD', () => {
             mockStatsdCallback(client.statsd.increment, undefined);
             await expect(client.increment('test', 3)).resolves.toEqual(undefined);
 
-            expect(mocked(client.statsd.increment)).toHaveBeenCalledWith('test', 3, expect.any(Function));
+            expect(mocked(client.statsd.increment)).toHaveBeenCalledWith('test', 3, undefined, expect.any(Function));
         });
 
         test('success - use default value', async () => {
             mockStatsdCallback(client.statsd.increment, undefined);
             await expect(client.increment('test')).resolves.toEqual(undefined);
 
-            expect(mocked(client.statsd.increment)).toHaveBeenCalledWith('test', 1, expect.any(Function));
+            expect(mocked(client.statsd.increment)).toHaveBeenCalledWith('test', 1, undefined, expect.any(Function));
         });
 
         test('error', async () => {
@@ -41,7 +41,7 @@ describe('AsyncStatsD', () => {
 
             await expect(client.increment('test', 3)).resolves.toEqual(undefined);
 
-            expect(mocked(client.statsd.increment)).toHaveBeenCalledWith('test', 3, expect.any(Function));
+            expect(mocked(client.statsd.increment)).toHaveBeenCalledWith('test', 3, undefined, expect.any(Function));
         });
     });
 
@@ -50,7 +50,7 @@ describe('AsyncStatsD', () => {
             mockStatsdCallback(client.statsd.timing, undefined);
             await expect(client.timing('test', 2000)).resolves.toEqual(undefined);
 
-            expect(mocked(client.statsd.timing)).toHaveBeenCalledWith('test', 2000, expect.any(Function));
+            expect(mocked(client.statsd.timing)).toHaveBeenCalledWith('test', 2000, undefined, expect.any(Function));
         });
 
         test('error', async () => {
@@ -58,7 +58,7 @@ describe('AsyncStatsD', () => {
 
             await expect(client.timing('test', 2000)).resolves.toEqual(undefined);
 
-            expect(mocked(client.statsd.timing)).toHaveBeenCalledWith('test', 2000, expect.any(Function));
+            expect(mocked(client.statsd.timing)).toHaveBeenCalledWith('test', 2000, undefined, expect.any(Function));
         });
     });
 
@@ -67,7 +67,7 @@ describe('AsyncStatsD', () => {
             mockStatsdCallback(client.statsd.gauge, undefined);
             await expect(client.gauge('test', 1)).resolves.toEqual(undefined);
 
-            expect(mocked(client.statsd.gauge)).toHaveBeenCalledWith('test', 1, expect.any(Function));
+            expect(mocked(client.statsd.gauge)).toHaveBeenCalledWith('test', 1, undefined, expect.any(Function));
         });
 
         test('error', async () => {
@@ -75,7 +75,7 @@ describe('AsyncStatsD', () => {
 
             await expect(client.gauge('test', 1)).resolves.toEqual(undefined);
 
-            expect(mocked(client.statsd.gauge)).toHaveBeenCalledWith('test', 1, expect.any(Function));
+            expect(mocked(client.statsd.gauge)).toHaveBeenCalledWith('test', 1, undefined, expect.any(Function));
         });
     });
 
@@ -126,10 +126,10 @@ interface MockStatsdCallbackOptions {
     error?: any;
 }
 
-function mockStatsdCallback(func: (_a: string, _b: number, cb: StatsCb) => void, opts: MockStatsdCallbackOptions = {}) {
+function mockStatsdCallback(func: (_a: string, _b: number, _t: Tags, cb: StatsCb) => void, opts: MockStatsdCallbackOptions = {}) {
     const {delay = 50, error = undefined} = opts;
 
-    mocked(func).mockImplementation((_a, _b, cb) => {
+    mocked(func).mockImplementation((_a, _b, _t, cb) => {
         setTimeout(() => cb(error, undefined), delay);
     });
 }

--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -2,25 +2,25 @@ import {mocked} from 'ts-jest/utils';
 import Monitor from '../src/Monitor';
 
 export function assertIncrementWasCalled(monitor: Monitor, metricName: string) {
-  expect(mocked(monitor.getStatsdClient()!.increment)).toHaveBeenCalledWith(metricName);
+  expect(mocked(monitor.getStatsdClient()!.increment)).toHaveBeenCalledWith(metricName, 1, undefined);
 }
 
 export function assertIncrementWasNotCalled(monitor: Monitor, metricName: string) {
-  expect(mocked(monitor.getStatsdClient()!.increment)).not.toHaveBeenCalledWith(metricName);
+  expect(mocked(monitor.getStatsdClient()!.increment)).not.toHaveBeenCalledWith(metricName, 1, undefined);
 }
 
 export function assertTimingWasCalled(monitor: Monitor, metricName: string) {
-  expect(mocked(monitor.getStatsdClient()!.timing)).toHaveBeenCalledWith(metricName, expect.any(Number));
+  expect(mocked(monitor.getStatsdClient()!.timing)).toHaveBeenCalledWith(metricName, expect.any(Number), undefined);
 }
 
 export function assertTimingWasNotCalled(monitor: Monitor, metricName: string) {
-  expect(mocked(monitor.getStatsdClient()!.timing)).not.toHaveBeenCalledWith(metricName, expect.any(Number));
+  expect(mocked(monitor.getStatsdClient()!.timing)).not.toHaveBeenCalledWith(metricName, expect.any(Number), undefined);
 }
 
 export function assertGaugeWasCalled(monitor: Monitor, metricName: string) {
-  expect(mocked(monitor.getStatsdClient()!.gauge)).toHaveBeenCalledWith(metricName, expect.any(Number));
+  expect(mocked(monitor.getStatsdClient()!.gauge)).toHaveBeenCalledWith(metricName, expect.any(Number), undefined);
 }
 
 export function assertGaugeWasNotCalled(monitor: Monitor, metricName: string) {
-  expect(mocked(monitor.getStatsdClient()!.gauge)).not.toHaveBeenCalledWith(metricName, expect.any(Number));
+  expect(mocked(monitor.getStatsdClient()!.gauge)).not.toHaveBeenCalledWith(metricName, expect.any(Number), undefined);
 }

--- a/src/AsyncStatsD.ts
+++ b/src/AsyncStatsD.ts
@@ -1,4 +1,4 @@
-import {StatsD, ClientOptions} from 'hot-shots';
+import {StatsD, ClientOptions, Tags} from 'hot-shots';
 import {promisify} from 'util';
 import {timeoutPromise} from './utils';
 import {Logger} from './Logger';
@@ -11,9 +11,9 @@ export class AsyncStatsD {
     private promiseCount: number;
     private pendingPromises: Record<number, Promise<any>>;
 
-    private _increment: (name: string, value: number) => Promise<void>;
-    private _gauge: (name: string, value: number) => Promise<void>;
-    private _timing: (name: string, value: number) => Promise<void>;
+    private _increment: (name: string, value: number, tags?: Tags) => Promise<void>;
+    private _gauge: (name: string, value: number, tags?: Tags) => Promise<void>;
+    private _timing: (name: string, value: number, tags?: Tags) => Promise<void>;
     close: () => Promise<void>;
 
     constructor(logger: Logger, options?: ClientOptions) {
@@ -32,25 +32,25 @@ export class AsyncStatsD {
         return this.client;
     }
 
-    increment = async (name: string, value: number = 1) => {
+    increment = async (name: string, value: number = 1, tags?: Tags) => {
         try {
-            await this.wrapStatsdPromise(this._increment(name, value));
+            await this.wrapStatsdPromise(this._increment(name, value, tags));
         } catch (err) {
             this.logger.error(`Failed to send increment: ${name}`, err);
         }
     };
 
-    gauge = async (name: string, value: number) => {
+    gauge = async (name: string, value: number, tags?: Tags) => {
         try {
-            await this.wrapStatsdPromise(this._gauge(name, value));
+            await this.wrapStatsdPromise(this._gauge(name, value, tags));
         } catch (err) {
             this.logger.error(`Failed to send gauge: ${name}`, err);
         }
     };
 
-    timing = async (name: string, value: number) => {
+    timing = async (name: string, value: number, tags?: Tags) => {
         try {
-            await this.wrapStatsdPromise(this._timing(name, value));
+            await this.wrapStatsdPromise(this._timing(name, value, tags));
         } catch (err) {
             this.logger.error(`Failed to send timing: ${name}`, err);
         }

--- a/src/Monitor.ts
+++ b/src/Monitor.ts
@@ -51,7 +51,7 @@ class Monitor {
         const startTime = Date.now();
 
         if (this.config.shouldMonitorExecutionStart) {
-            this.increment(`${name}.start`);
+            this.increment(`${name}.start`, 1, options?.tags);
             this.monitoredLogger(level, `${name}.start`, {extra: context});
         }
 
@@ -93,14 +93,14 @@ class Monitor {
         result: Unpromisify<T>,
         name: string,
         startTime: number,
-        {shouldMonitorSuccess, context, parseResult, logResult, level}: MonitoredOptions<T>
+        {shouldMonitorSuccess, context, parseResult, logResult, level, tags}: MonitoredOptions<T>
     ): Unpromisify<T> => {
         const executionTime = Date.now() - startTime;
 
         if (shouldMonitorSuccess?.(result) ?? true) {
-            this.increment(`${name}.success`);
-            this.gauge(`${name}.ExecutionTime`, executionTime);
-            this.timing(`${name}.ExecutionTime`, executionTime);
+            this.increment(`${name}.success`, 1, tags);
+            this.gauge(`${name}.ExecutionTime`, executionTime, tags);
+            this.timing(`${name}.ExecutionTime`, executionTime, tags);
         }
 
         if (!this.config.disableSuccessLogs) {
@@ -119,10 +119,10 @@ class Monitor {
     private onErrorAsync = async (
         err,
         name: string,
-        {shouldMonitorError, context, logAsError, logErrorAsInfo, parseError}: MonitoredOptions<never>
+        {shouldMonitorError, context, logAsError, logErrorAsInfo, parseError, tags}: MonitoredOptions<never>
     ) => {
         if (shouldMonitorError && !shouldMonitorError(err)) throw err;
-        this.increment(`${name}.error`);
+        this.increment(`${name}.error`, 1, tags);
         this.logger.error(
             `${name}.error`,
             await safe(parseError || this.defaultParseError)(err),
@@ -136,10 +136,10 @@ class Monitor {
     private onErrorSync = (
         err,
         name: string,
-        {shouldMonitorError, context, logAsError, logErrorAsInfo, parseError}: MonitoredOptions<never>
+        {shouldMonitorError, context, logAsError, logErrorAsInfo, parseError, tags}: MonitoredOptions<never>
     ) => {
         if (shouldMonitorError && shouldMonitorError(err)) throw err;
-        this.increment(`${name}.error`);
+        this.increment(`${name}.error`, 1, tags);
         this.logger.error(
             `${name}.error`,
             safe(parseError || this.defaultParseError)(err),

--- a/src/Monitor.ts
+++ b/src/Monitor.ts
@@ -35,7 +35,7 @@ class Monitor {
             if (options.serviceName) {
                 prefixesArray.push(options.serviceName);
             }
-            const prefix = `${prefixesArray.join('.')}.`;
+            const prefix = `${prefixesArray.filter(element => element).join('.')}.`;
 
             this.statsdClient = new AsyncStatsD(this.logger, {
                 port: port ?? 8125,

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,4 +32,5 @@ export type MonitoredOptions<T> = {
   logErrorAsInfo?: boolean,
   shouldMonitorError?: (e: any) => boolean;
   shouldMonitorSuccess?: (r: Unpromisify<T>) => boolean;
+  tags?: StatsdTags;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import {ClientOptions as StatsdClientOptions} from 'hot-shots';
+import {ClientOptions as StatsdClientOptions, Tags as StatsdTags} from 'hot-shots';
 
 interface StatsdOptions extends Omit<StatsdClientOptions, 'prefix'> {
   apiKey: string;


### PR DESCRIPTION
Allow for empty prefixes - 

When there's an empty prefix (serviceName, root, or apiKey), don't add it to the metrics path.
Example - `apiKey: ''`

So instead of: `.ROOT_SERVICE` the metrics path will be `ROOT_SERVICE`



Adds statsd tags support to monitored

Enhance integration with prometheus-stastd-exporter.
The exporter converts statsd tags to prometheus labels.