### PR TITLE
ci: change PR workflow to verify node16 instead of node15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Which issues does it affect?

## What it does

Change the matrix of node version in the CI pipeline to use node 16 instead of 15 (which is not LTS)

## What else do I need to know?

-   ...
