### PR TITLE
Support typed increment

### DIFF
--- a/example/run.ts
+++ b/example/run.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 
-import {setGlobalInstance, StatsdPlugin, monitored, Monitor} from '../src';
+import {setGlobalInstance, StatsdPlugin, monitored, Monitor, increment} from '../src';
 
 setGlobalInstance(
     new Monitor({
@@ -97,3 +97,10 @@ monitored(
     },
     {logErrorAsInfo: true}
 ).catch(() => {});
+
+// Increment
+increment('metric1');
+
+// Increment with type restriction
+type Color = 'red' | 'orange' | 'green';
+increment<Color>('red');

--- a/src/plugins/PluginsWrapper.ts
+++ b/src/plugins/PluginsWrapper.ts
@@ -17,7 +17,7 @@ export class PluginsWrapper implements Omit<MonitoredPlugin, 'initialize'> {
         this.plugins.forEach(p => p.onFailure(opts));
     }
 
-    async increment(name: string, value?: number, tags?: Record<string, string>): Promise<void> {
+    async increment<T extends string>(name: T, value?: number, tags?: Record<string, string>): Promise<void> {
         await Promise.all(this.plugins.map(p => p.increment(name, value, tags)));
     }
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -34,7 +34,7 @@ export interface MonitoredPlugin {
 
     onFailure(opts: OnFailureOptions): void;
 
-    increment(name: string, value?: number, tags?: Record<string, string>): Promise<void>;
+    increment<T extends string>(name: T, value?: number, tags?: Record<string, string>): Promise<void>;
 
     gauge(name: string, value?: number, tags?: Record<string, string>): Promise<void>;
 


### PR DESCRIPTION
## Which issues does it affect?

-  Closes  #43 

## What it does

-  Support typed value for `increment` method
-  help enforce metrics name in a typed manner at compile time using typescript
for example, it is now possible todo 
```ts
// Increment with type restriction
type Color = 'red' | 'orange' | 'green';
increment<Color>('red');
```

## What else do I need to know?
-  I think this can also be a more generic solution for #39 
especially on the avoiding typos issue, for example
```ts
// Increment with type restriction
type InvocationFooResult = `foo.${'success' | 'error'}`;
increment<InvocationResult>('foo.success');
```
