### PR TITLE
Report result was found or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ npm install monitored
 To wire this package, you must pass an `Options` object.
 
 ```ts
+import { setGlobalInstance, Monitor } from 'monitored';
+
 interface MonitorOptions {
     serviceName: string; // Represents the name of the service you are monitoring (mandatory)
     plugins: MonitoredPlugin[]; // Stats plugins, statsD and/or prometheus (mandatory)
@@ -147,7 +149,10 @@ Wait until all current metrics are sent to the server. <br>
 We recommend using it at the end of lambda execution to ensure all metrics are sent.
 
 ```ts
-await monitor.flush(timeout: number = 2000)
+import { getGlobalInstance } from 'monitored';
+
+const flushTimeout: number = 2000;
+await getGlobalInstance().flush(flushTimeout)
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ type MonitoredOptions = {
     level?: 'info' | 'debug'; //which log level to write (debug is the default)
     logAsError?: boolean; //enables to write error log in case the global `logErrorsAsWarnings` is on
     logErrorAsInfo?: boolean //enables to write the error as info log
-    shouldMonitorError: e => boolean //determines if error should be monitored and logged, defaults to true
-    shouldMonitorSuccess: (r: T) => boolean //determines if success result should be monitored and logged, defaults to true
+    shouldMonitorError: e => boolean // define the conditions of reporting and logging an error, defaults to true
+    shouldMonitorSuccess: (r: T) => boolean // define the conditions of reporting and logging wether a result was successful or not, defaults to true
     tags?: Record<string, string>; //add more information/labels to metrics
-    isResultFound?: (r: Awaited<T>) => boolean; // predicate, define the conditions of reporting wether a result was empty or not
+    shouldMonitorResultFound?: (r: Awaited<T>) => boolean; // define the conditions of reporting wether a result was found or not, defaults to false
 };
 ```
 
@@ -144,7 +144,7 @@ const result = monitored(
 );
 ```
 
-#### You can report an empty result by defining a predicate in  `isResultFound`:
+#### You can report an empty result by defining a predicate in  `shouldMonitorResultFound`:
 
 ```ts
 const result = monitored(
@@ -152,7 +152,7 @@ const result = monitored(
     () => {
         return [1, 2, 3];
     },
-    {context: {id: 'some context'}, isResultFound: (result)=>{return result.length > 0}}
+    {context: {id: 'some context'}, shouldMonitorResultFound: (result)=>{return result.length > 0}}
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ type MonitoredOptions = {
     shouldMonitorError: e => boolean //determines if error should be monitored and logged, defaults to true
     shouldMonitorSuccess: (r: T) => boolean //determines if success result should be monitored and logged, defaults to true
     tags?: Record<string, string>; //add more information/labels to metrics
+    isResultFound?: (r: Awaited<T>) => boolean; // predicate, define the conditions of reporting wether a result was empty or not
 };
 ```
 
@@ -140,6 +141,18 @@ const result = monitored(
         console.log('example');
     },
     {context: {id: 'some context'}, logResult: true}
+);
+```
+
+#### You can report an empty result by defining a predicate in  `isResultFound`:
+
+```ts
+const result = monitored(
+    'functionName',
+    () => {
+        return [1, 2, 3];
+    },
+    {context: {id: 'some context'}, isResultFound: (result)=>{return result.length > 0}}
 );
 ```
 

--- a/__tests__/PrometheusPlugin.spec.ts
+++ b/__tests__/PrometheusPlugin.spec.ts
@@ -18,6 +18,10 @@ const gauge = {
     labels: jest.fn().mockImplementation(() => ({set: gaugeSet})),
 };
 
+const isResultFoundCallable = (result: Awaited<number[]>): boolean => {
+    return result.length > 0;
+};
+
 jest.mock('prom-client', () => ({
     Histogram: jest.fn().mockImplementation(() => histogram),
     Counter: jest.fn().mockImplementation(() => counter),
@@ -64,6 +68,60 @@ describe('PrometheusPlugin', () => {
         expect(counterInc).toHaveBeenCalledWith(1);
         expect(counter.labels).toHaveBeenCalledWith({result: 'success'});
         expect(counterInc).toHaveBeenCalledWith(1);
+        expect(counter.labels).not.toHaveBeenCalledWith({result: 'found'});
+        expect(counter.labels).not.toHaveBeenCalledWith({result: 'notFound'});
+        expect(histogram.labels).toHaveBeenCalledWith({result: 'success'});
+        expect(histogramObserve).toHaveBeenCalledWith(expect.any(Number));
+    });
+
+    it('reports result found on onSuccess', () => {
+        monitor.monitored('abc', () => [1, 2, 3], {isResultFound: isResultFoundCallable});
+
+        expect(Counter).toHaveBeenCalledWith({
+            name: `abc_count`,
+            help: `abc_count`,
+            labelNames: ['result'],
+        });
+
+        expect(Histogram).toHaveBeenCalledWith({
+            name: `abc_execution_time`,
+            help: `abc_execution_time`,
+            buckets: DEFAULT_BUCKETS,
+            labelNames: ['result'],
+        });
+
+        expect(counter.labels).toHaveBeenCalledWith({result: 'start'});
+        expect(counterInc).toHaveBeenCalledWith(1);
+        expect(counter.labels).toHaveBeenCalledWith({result: 'success'});
+        expect(counterInc).toHaveBeenCalledWith(1);
+        expect(counter.labels).toHaveBeenCalledWith({result: 'found'});
+        expect(counterInc).toHaveBeenCalledWith(1);
+        expect(histogram.labels).toHaveBeenCalledWith({result: 'success'});
+        expect(histogramObserve).toHaveBeenCalledWith(expect.any(Number));
+    });
+
+    it('reports result not found on onSuccess', () => {
+        monitor.monitored('abc', () => [], {isResultFound: isResultFoundCallable});
+
+        expect(Counter).toHaveBeenCalledWith({
+            name: `abc_count`,
+            help: `abc_count`,
+            labelNames: ['result'],
+        });
+
+        expect(Histogram).toHaveBeenCalledWith({
+            name: `abc_execution_time`,
+            help: `abc_execution_time`,
+            buckets: DEFAULT_BUCKETS,
+            labelNames: ['result'],
+        });
+
+        expect(counter.labels).toHaveBeenCalledWith({result: 'start'});
+        expect(counterInc).toHaveBeenCalledWith(1);
+        expect(counter.labels).toHaveBeenCalledWith({result: 'success'});
+        expect(counterInc).toHaveBeenCalledWith(1);
+        expect(counter.labels).toHaveBeenCalledWith({result: 'notFound'});
+        expect(counterInc).toHaveBeenCalledWith(1);
         expect(histogram.labels).toHaveBeenCalledWith({result: 'success'});
         expect(histogramObserve).toHaveBeenCalledWith(expect.any(Number));
     });
@@ -79,6 +137,30 @@ describe('PrometheusPlugin', () => {
         expect(counterInc).toHaveBeenCalledWith(1);
         expect(counter.labels).toHaveBeenCalledWith({result: 'failure'});
         expect(counterInc).toHaveBeenCalledWith(1);
+        expect(counter.labels).not.toHaveBeenCalledWith({result: 'found'});
+        expect(counter.labels).not.toHaveBeenCalledWith({result: 'notFound'});
+    });
+
+    it('not to report result found onFailure', () => {
+        expect(() =>
+            monitor.monitored(
+                'abc',
+                () => {
+                    if (false) {
+                        return [1, 2];
+                    }
+                    throw new Error('123');
+                },
+                {isResultFound: isResultFoundCallable}
+            )
+        ).toThrow();
+
+        expect(counter.labels).toHaveBeenCalledWith({result: 'start'});
+        expect(counterInc).toHaveBeenCalledWith(1);
+        expect(counter.labels).toHaveBeenCalledWith({result: 'failure'});
+        expect(counterInc).toHaveBeenCalledWith(1);
+        expect(counter.labels).not.toHaveBeenCalledWith({result: 'found'});
+        expect(counter.labels).not.toHaveBeenCalledWith({result: 'notFound'});
     });
 
     it('should call registry', () => {

--- a/__tests__/PrometheusPlugin.spec.ts
+++ b/__tests__/PrometheusPlugin.spec.ts
@@ -18,7 +18,7 @@ const gauge = {
     labels: jest.fn().mockImplementation(() => ({set: gaugeSet})),
 };
 
-const isResultFoundCallable = (result: Awaited<number[]>): boolean => {
+const isResultFoundCallback = (result: Awaited<number[]>): boolean => {
     return result.length > 0;
 };
 
@@ -75,7 +75,7 @@ describe('PrometheusPlugin', () => {
     });
 
     it('reports result found on onSuccess', () => {
-        monitor.monitored('abc', () => [1, 2, 3], {isResultFound: isResultFoundCallable});
+        monitor.monitored('abc', () => [1, 2, 3], {shouldMonitorResultFound: isResultFoundCallback});
 
         expect(Counter).toHaveBeenCalledWith({
             name: `abc_count`,
@@ -101,7 +101,7 @@ describe('PrometheusPlugin', () => {
     });
 
     it('reports result not found on onSuccess', () => {
-        monitor.monitored('abc', () => [], {isResultFound: isResultFoundCallable});
+        monitor.monitored('abc', () => [], {shouldMonitorResultFound: isResultFoundCallback});
 
         expect(Counter).toHaveBeenCalledWith({
             name: `abc_count`,
@@ -151,7 +151,7 @@ describe('PrometheusPlugin', () => {
                     }
                     throw new Error('123');
                 },
-                {isResultFound: isResultFoundCallable}
+                {shouldMonitorResultFound: isResultFoundCallback}
             )
         ).toThrow();
 

--- a/__tests__/StatsdPlugin.spec.ts
+++ b/__tests__/StatsdPlugin.spec.ts
@@ -81,24 +81,22 @@ describe('StatsdPlugin', () => {
 
     test('onFailure dont report result is found', () => {
         expect(() => {
-            monitor
-                .monitored(
-                    'abc',
-                    () => {
-                        if (false) {
-                            return [1];
-                        }
-                        throw new Error('123');
-                    },
-                    {shouldMonitorResultFound: isResultFoundCallback}
-                )
-                .toThrow(new Error('error'));
+            monitor.monitored(
+                'abc',
+                () => {
+                    if (false) {
+                        return [1, 2];
+                    }
+                    throw new Error('123');
+                },
+                {shouldMonitorResultFound: isResultFoundCallback}
+            );
+        }).toThrow(new Error('123'));
 
-            assertIncrementWasCalled(plugin, 'abc.start');
-            assertIncrementWasCalled(plugin, 'abc.error');
-            assertIncrementWasNotCalled(plugin, 'abc.result.found');
-            assertIncrementWasNotCalled(plugin, 'abc.result.notFound');
-        });
+        assertIncrementWasCalled(plugin, 'abc.start');
+        assertIncrementWasCalled(plugin, 'abc.error');
+        assertIncrementWasNotCalled(plugin, 'abc.result.found');
+        assertIncrementWasNotCalled(plugin, 'abc.result.notFound');
     });
 });
 

--- a/__tests__/StatsdPlugin.spec.ts
+++ b/__tests__/StatsdPlugin.spec.ts
@@ -42,7 +42,7 @@ describe('StatsdPlugin', () => {
     });
 
     test('onSuccess report result is found', () => {
-        monitor.monitored('abc', () => [1, 2], {isResultFound: isResultFoundCallable});
+        monitor.monitored('abc', () => [1, 2], {shouldMonitorResultFound: isResultFoundCallable});
 
         assertIncrementWasCalled(plugin, 'abc.start');
         assertIncrementWasCalled(plugin, 'abc.result.found');
@@ -51,7 +51,7 @@ describe('StatsdPlugin', () => {
     });
 
     test('onSuccess report result is not found', () => {
-        monitor.monitored('abc', () => [], {isResultFound: isResultFoundCallable});
+        monitor.monitored('abc', () => [], {shouldMonitorResultFound: isResultFoundCallable});
 
         assertIncrementWasCalled(plugin, 'abc.start');
         assertIncrementWasCalled(plugin, 'abc.result.notFound');
@@ -90,7 +90,7 @@ describe('StatsdPlugin', () => {
                         }
                         throw new Error('123');
                     },
-                    {isResultFound: isResultFoundCallable}
+                    {shouldMonitorResultFound: isResultFoundCallable}
                 )
                 .toThrow(new Error('error'));
 

--- a/__tests__/StatsdPlugin.spec.ts
+++ b/__tests__/StatsdPlugin.spec.ts
@@ -12,7 +12,7 @@ import {MockStatsdPlugin} from './__mocks__/plugins/StatsdPlugin';
 
 jest.mock('hot-shots');
 
-const isResultFoundCallable = (result: Awaited<number[]>): boolean => {
+const isResultFoundCallback = (result: Awaited<number[]>): boolean => {
     return result.length > 0;
 };
 
@@ -42,7 +42,7 @@ describe('StatsdPlugin', () => {
     });
 
     test('onSuccess report result is found', () => {
-        monitor.monitored('abc', () => [1, 2], {shouldMonitorResultFound: isResultFoundCallable});
+        monitor.monitored('abc', () => [1, 2], {shouldMonitorResultFound: isResultFoundCallback});
 
         assertIncrementWasCalled(plugin, 'abc.start');
         assertIncrementWasCalled(plugin, 'abc.result.found');
@@ -51,7 +51,7 @@ describe('StatsdPlugin', () => {
     });
 
     test('onSuccess report result is not found', () => {
-        monitor.monitored('abc', () => [], {shouldMonitorResultFound: isResultFoundCallable});
+        monitor.monitored('abc', () => [], {shouldMonitorResultFound: isResultFoundCallback});
 
         assertIncrementWasCalled(plugin, 'abc.start');
         assertIncrementWasCalled(plugin, 'abc.result.notFound');
@@ -90,7 +90,7 @@ describe('StatsdPlugin', () => {
                         }
                         throw new Error('123');
                     },
-                    {shouldMonitorResultFound: isResultFoundCallable}
+                    {shouldMonitorResultFound: isResultFoundCallback}
                 )
                 .toThrow(new Error('error'));
 

--- a/__tests__/StatsdPlugin.spec.ts
+++ b/__tests__/StatsdPlugin.spec.ts
@@ -2,10 +2,19 @@ import {StatsCb, Tags} from 'hot-shots';
 import {mocked} from 'jest-mock';
 import Monitor from '../src/Monitor';
 import {StatsdPlugin, StatsdPluginOptions} from '../src/plugins/StatsdPlugin';
-import {assertGaugeWasCalled, assertIncrementWasCalled, assertTimingWasCalled} from './utils';
+import {
+    assertGaugeWasCalled,
+    assertIncrementWasCalled,
+    assertIncrementWasNotCalled,
+    assertTimingWasCalled,
+} from './utils';
 import {MockStatsdPlugin} from './__mocks__/plugins/StatsdPlugin';
 
 jest.mock('hot-shots');
+
+const isResultFoundCallable = (result: Awaited<number[]>): boolean => {
+    return result.length > 0;
+};
 
 beforeEach(() => {
     jest.resetAllMocks();
@@ -26,6 +35,26 @@ describe('StatsdPlugin', () => {
         monitor.monitored('abc', () => 123);
 
         assertIncrementWasCalled(plugin, 'abc.start');
+        assertIncrementWasNotCalled(plugin, 'abc.result.found');
+        assertIncrementWasNotCalled(plugin, 'abc.result.notFound');
+        assertGaugeWasCalled(plugin, 'abc.ExecutionTime');
+        assertTimingWasCalled(plugin, 'abc.ExecutionTime');
+    });
+
+    test('onSuccess report result is found', () => {
+        monitor.monitored('abc', () => [1, 2], {isResultFound: isResultFoundCallable});
+
+        assertIncrementWasCalled(plugin, 'abc.start');
+        assertIncrementWasCalled(plugin, 'abc.result.found');
+        assertGaugeWasCalled(plugin, 'abc.ExecutionTime');
+        assertTimingWasCalled(plugin, 'abc.ExecutionTime');
+    });
+
+    test('onSuccess report result is not found', () => {
+        monitor.monitored('abc', () => [], {isResultFound: isResultFoundCallable});
+
+        assertIncrementWasCalled(plugin, 'abc.start');
+        assertIncrementWasCalled(plugin, 'abc.result.notFound');
         assertGaugeWasCalled(plugin, 'abc.ExecutionTime');
         assertTimingWasCalled(plugin, 'abc.ExecutionTime');
     });
@@ -46,6 +75,30 @@ describe('StatsdPlugin', () => {
 
         assertIncrementWasCalled(plugin, 'abc.start');
         assertIncrementWasCalled(plugin, 'abc.error');
+        assertIncrementWasNotCalled(plugin, 'abc.result.found');
+        assertIncrementWasNotCalled(plugin, 'abc.result.notFound');
+    });
+
+    test('onFailure dont report result is found', () => {
+        expect(() => {
+            monitor
+                .monitored(
+                    'abc',
+                    () => {
+                        if (false) {
+                            return [1];
+                        }
+                        throw new Error('123');
+                    },
+                    {isResultFound: isResultFoundCallable}
+                )
+                .toThrow(new Error('error'));
+
+            assertIncrementWasCalled(plugin, 'abc.start');
+            assertIncrementWasCalled(plugin, 'abc.error');
+            assertIncrementWasNotCalled(plugin, 'abc.result.found');
+            assertIncrementWasNotCalled(plugin, 'abc.result.notFound');
+        });
     });
 });
 

--- a/__tests__/__mocks__/plugins/StatsdPlugin.ts
+++ b/__tests__/__mocks__/plugins/StatsdPlugin.ts
@@ -7,6 +7,7 @@ export class MockStatsdPlugin {
     onStart = StatsdPlugin.prototype.onStart;
     onSuccess = StatsdPlugin.prototype.onSuccess;
     onFailure = StatsdPlugin.prototype.onFailure;
+    reportResultIsFound = StatsdPlugin.prototype.reportResultIsFound;
     increment = jest.fn();
     gauge = jest.fn();
     timing = jest.fn();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monitored",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A utility for monitoring services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Monitor.ts
+++ b/src/Monitor.ts
@@ -58,11 +58,18 @@ class Monitor {
         startTime: number,
         options: MonitoredOptions<T>
     ): Awaited<T> {
-        const {shouldMonitorSuccess, logResult, level = 'debug', context, parseResult} = options;
+        const {shouldMonitorSuccess, logResult, level = 'debug', context, parseResult, isResultFound} = options;
         const executionTime = Date.now() - startTime;
 
         if (shouldMonitorSuccess?.(result) ?? true) {
             this.plugins.onSuccess({scope, executionTime, options});
+        }
+
+        if (isResultFound) {
+            try {
+                const isFound = isResultFound(result);
+                this.plugins.reportResultIsFound({scope, options}, isFound);
+            } catch {}
         }
 
         if (!this.config.disableSuccessLogs) {

--- a/src/Monitor.ts
+++ b/src/Monitor.ts
@@ -58,18 +58,27 @@ class Monitor {
         startTime: number,
         options: MonitoredOptions<T>
     ): Awaited<T> {
-        const {shouldMonitorSuccess, logResult, level = 'debug', context, parseResult, isResultFound} = options;
+        const {
+            shouldMonitorSuccess,
+            logResult,
+            level = 'debug',
+            context,
+            parseResult,
+            shouldMonitorResultFound,
+        } = options;
         const executionTime = Date.now() - startTime;
 
         if (shouldMonitorSuccess?.(result) ?? true) {
             this.plugins.onSuccess({scope, executionTime, options});
         }
 
-        if (isResultFound) {
+        if (shouldMonitorResultFound) {
             try {
-                const isFound = isResultFound(result);
+                const isFound = shouldMonitorResultFound(result);
                 this.plugins.reportResultIsFound({scope, options}, isFound);
-            } catch {}
+            } catch {
+                this.monitoredLogger('debug', 'isResultFound callback failed', {extra: {context}});
+            }
         }
 
         if (!this.config.disableSuccessLogs) {

--- a/src/plugins/PluginsWrapper.ts
+++ b/src/plugins/PluginsWrapper.ts
@@ -1,4 +1,11 @@
-import {InitializationOptions, MonitoredPlugin, OnFailureOptions, OnStartOptions, OnSuccessOptions} from './types';
+import {
+    EventOptions,
+    InitializationOptions,
+    MonitoredPlugin,
+    OnFailureOptions,
+    OnStartOptions,
+    OnSuccessOptions,
+} from './types';
 
 export class PluginsWrapper implements Omit<MonitoredPlugin, 'initialize'> {
     constructor(private readonly plugins: MonitoredPlugin[], opts: InitializationOptions) {
@@ -15,6 +22,10 @@ export class PluginsWrapper implements Omit<MonitoredPlugin, 'initialize'> {
 
     onFailure(opts: OnFailureOptions): void {
         this.plugins.forEach(p => p.onFailure(opts));
+    }
+
+    reportResultIsFound(opts: EventOptions, isFound: boolean): void {
+        this.plugins.forEach(p => p.reportResultIsFound(opts, isFound));
     }
 
     async increment(name: string, value?: number, tags?: Record<string, string>): Promise<void> {

--- a/src/plugins/PrometheusPlugin.ts
+++ b/src/plugins/PrometheusPlugin.ts
@@ -1,5 +1,5 @@
 import {Counter, Histogram, register as registry, Gauge} from 'prom-client';
-import {MonitoredPlugin, OnFailureOptions, OnStartOptions, OnSuccessOptions} from './types';
+import {EventOptions, MonitoredPlugin, OnFailureOptions, OnStartOptions, OnSuccessOptions} from './types';
 
 export interface PrometheusPluginOptions {
     histogramBuckets?: number[];
@@ -29,6 +29,12 @@ export class PrometheusPlugin implements MonitoredPlugin {
         const labels = {result: 'failure', ...options?.tags};
         this.increment(scope, 1, labels);
         this.timing(scope, executionTime, labels);
+    }
+
+    reportResultIsFound({scope, options}: EventOptions, isFound: boolean): void {
+        const isFoundLabel = isFound ? 'found' : 'notFound';
+        const labels = {result: isFoundLabel, ...options?.tags};
+        this.increment(scope, 1, labels);
     }
 
     private getMetrics(scope: string) {

--- a/src/plugins/StatsdPlugin.ts
+++ b/src/plugins/StatsdPlugin.ts
@@ -2,7 +2,14 @@ import {ClientOptions, StatsD, Tags} from 'hot-shots';
 import {promisify} from 'util';
 import {timeoutPromise} from '../utils';
 import {Logger} from '../Logger';
-import {InitializationOptions, MonitoredPlugin, OnFailureOptions, OnStartOptions, OnSuccessOptions} from './types';
+import {
+    EventOptions,
+    InitializationOptions,
+    MonitoredPlugin,
+    OnFailureOptions,
+    OnStartOptions,
+    OnSuccessOptions,
+} from './types';
 
 const noop = () => {};
 
@@ -65,6 +72,11 @@ export class StatsdPlugin implements MonitoredPlugin {
         this.increment(`${scope}.error`, 1, options?.tags);
     }
 
+    reportResultIsFound({scope, options}: EventOptions, isFound: boolean): void {
+        const isFoundLabel = isFound ? 'found' : 'notFound';
+        this.increment(`${scope}.result.${isFoundLabel}`, 1, options?.tags);
+    }
+
     get statsd() {
         return this.client;
     }
@@ -94,7 +106,7 @@ export class StatsdPlugin implements MonitoredPlugin {
     }
 
     async flush(timeout: number = 2000) {
-        const remainingPromises = Object.values(this.pendingPromises).map((p) => p.catch(noop));
+        const remainingPromises = Object.values(this.pendingPromises).map(p => p.catch(noop));
         if (!remainingPromises.length) {
             return true;
         }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -34,6 +34,8 @@ export interface MonitoredPlugin {
 
     onFailure(opts: OnFailureOptions): void;
 
+    reportResultIsFound(opts: EventOptions, isFound: boolean): void;
+
     increment(name: string, value?: number, tags?: Record<string, string>): Promise<void>;
 
     gauge(name: string, value?: number, tags?: Record<string, string>): Promise<void>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,5 +19,5 @@ export interface MonitoredOptions<T> extends MetricOptions {
     logAsError?: boolean;
     logErrorAsInfo?: boolean;
     shouldMonitorSuccess?: (r: Awaited<T>) => boolean;
-    isResultFound?: (r: Awaited<T>) => boolean;
+    shouldMonitorResultFound?: (r: Awaited<T>) => boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,4 +19,5 @@ export interface MonitoredOptions<T> extends MetricOptions {
     logAsError?: boolean;
     logErrorAsInfo?: boolean;
     shouldMonitorSuccess?: (r: Awaited<T>) => boolean;
+    isResultFound?: (r: Awaited<T>) => boolean;
 }


### PR DESCRIPTION
## Which issues does it affect?

-   Applies to #41

## What it does

-   Allows to define under which conditions a result is considered 'found' or 'not found' and report a metric for each case.


